### PR TITLE
Update eos.py

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -2132,8 +2132,9 @@ class EOSDriver(NetworkDriver):
         output = self._show_vrf()
 
         vrfs = [str(vrf["name"]) for vrf in output]
-
-        vrfs.append("default")
+        
+        if "default" not in vrfs:
+            vrfs.append("default")
 
         return vrfs
 


### PR DESCRIPTION
Fixes #1919

Add VRF `default` only if it's non-existent.